### PR TITLE
Copy the default items before returning them, to prevent modification…

### DIFF
--- a/todo_app/data/session_items.py
+++ b/todo_app/data/session_items.py
@@ -13,7 +13,7 @@ def get_items():
     Returns:
         list: The list of saved items.
     """
-    return session.get('items', _DEFAULT_ITEMS)
+    return session.get('items', _DEFAULT_ITEMS.copy())
 
 
 def get_item(id):


### PR DESCRIPTION
Copy the default items before returning them, to prevent modifications persisting

Currently when adding/updating the first item, the default items array is changed which can lead to confusing results.