### PR TITLE
Set variables on the app config in the config constructor rather than…

### DIFF
--- a/todo_app/app.py
+++ b/todo_app/app.py
@@ -3,13 +3,9 @@ from flask import Flask
 from todo_app.flask_config import Config
 
 app = Flask(__name__)
-app.config.from_object(Config)
+app.config.from_object(Config())
 
 
 @app.route('/')
 def index():
     return 'Hello World!'
-
-
-if __name__ == '__main__':
-    app.run()

--- a/todo_app/flask_config.py
+++ b/todo_app/flask_config.py
@@ -2,7 +2,8 @@ import os
 
 
 class Config:
-    """Base configuration variables."""
-    SECRET_KEY = os.environ.get('SECRET_KEY')
-    if not SECRET_KEY:
-        raise ValueError("No SECRET_KEY set for Flask application. Did you follow the setup instructions?")
+    def __init__(self):
+        """Base configuration variables."""
+        self.SECRET_KEY = os.environ.get('SECRET_KEY')
+        if not self.SECRET_KEY:
+            raise ValueError("No SECRET_KEY set for Flask application. Did you follow the setup instructions?")


### PR DESCRIPTION
… as class variables, also remove the main run block

Removed the main run block as we don't use it, and it often leads to confusion (also I can see another branch already did this but isn't merged)